### PR TITLE
Sanitize symbol names

### DIFF
--- a/golang_symbol_restore.py
+++ b/golang_symbol_restore.py
@@ -1,9 +1,20 @@
 #!/usr/bin/env python3
 
+import re
 import struct
 
 import binaryninja
 from binaryninja.log import log_error, log_info
+
+
+_RE_REPLACE_UNDERSCORE = re.compile("[^a-zA-Z0-9_]")
+_RE_COMPRESS_UNDERSCORE = re.compile("__+")
+
+
+def sanitize_func_name(name):
+    varname = _RE_REPLACE_UNDERSCORE.sub("_", name)
+    varname = _RE_COMPRESS_UNDERSCORE.sub("_", varname)
+    return varname
 
 
 def is_gopclntab_section(view: binaryninja.binaryview.BinaryView,
@@ -86,7 +97,8 @@ def restore_symbols(view: binaryninja.binaryview.BinaryView,
         if not function:
             view.create_user_function(function_addr)
             function = view.get_function_at(function_addr)
-        function.name = function_name.value
+
+        function.name = sanitize_func_name(function_name.value)
 
 
 def restore_golang_symbols(view: binaryninja.binaryview.BinaryView):

--- a/golang_symbol_restore.py
+++ b/golang_symbol_restore.py
@@ -98,6 +98,10 @@ def restore_symbols(view: binaryninja.binaryview.BinaryView,
             view.create_user_function(function_addr)
             function = view.get_function_at(function_addr)
 
+        new_func_comment = function_name.value
+        if function.comment:
+            new_func_comment += "\n\n{}".format(function.comment)
+        function.comment = new_func_comment
         function.name = sanitize_func_name(function_name.value)
 
 


### PR DESCRIPTION
Even though binja allows setting any function name from the API, only some are allowed through the GUI. Because of this, changing some signature from the GUI requires to manually rewrite the symbol name to something binja likes (which seems to be something close to `[A-Za-z][A-Za-z0-9]*`)